### PR TITLE
Resolve pip build time dependency error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel", "cython", "numpy < 2.0"]
+build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,8 @@
 [build-system]
 requires = ["setuptools", "wheel", "cython", "numpy < 2.0"]
 build-backend = "setuptools.build_meta"
+
+[project]
+name = "fseq2"
+version = "2.0.4"
+dynamic = ["dependencies"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,3 @@
 [build-system]
 requires = ["setuptools", "wheel", "cython", "numpy < 2.0"]
 build-backend = "setuptools.build_meta"
-
-[project]
-name = "fseq2"
-version = "2.0.4"
-dynamic = ["dependencies"]

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,6 @@
 from setuptools import setup, find_packages, Extension
 import sys
 from pathlib import Path
-import numpy
 
 # with open('README.rst') as readme_file:
 #     readme = readme_file.read()
@@ -30,12 +29,14 @@ test_requirements = ['pytest>=3']
 
 try:
     from Cython.Build import cythonize
+    import numpy
     extensions = cythonize([
         Extension("fseq2.idr_2_0_3.inv_cdf",
                   ["fseq2/idr_2_0_3/inv_cdf.pyx", ],
                   include_dirs=[numpy.get_include()]),
     ])
 except ImportError:
+    import numpy
     extensions = [
         Extension("fseq2.idr_2_0_3.inv_cdf",
                   ["fseq2/idr_2_0_3/inv_cdf.c", ],


### PR DESCRIPTION
Currently numpy is a build time dependency, which is anti pattern to python, as well as makes it difficult to install with pip, as you have to have numpy installed prior to attempting to install fseq2. This pull slightly modernizes the build tooling and resolves the issue.